### PR TITLE
Add share menus and multi-plan weekly planner

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -85,6 +85,43 @@ body {
   gap: 0.75rem;
 }
 
+.icon-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.icon-label .icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.icon-label .label {
+  white-space: nowrap;
+}
+
+button.icon-only {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .user-badge {
   padding: 0.5rem 1rem;
   background: rgba(56, 189, 248, 0.2);
@@ -218,6 +255,48 @@ main.layout {
   gap: 0.75rem;
 }
 
+.share-control {
+  position: relative;
+  display: inline-flex;
+}
+
+.share-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 0.4rem;
+  box-shadow: var(--shadow-medium);
+  display: grid;
+  gap: 0.25rem;
+  min-width: 12.5rem;
+  z-index: 20;
+}
+
+.share-option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.share-option .icon {
+  font-size: 1.05rem;
+}
+
+.share-option:hover,
+.share-option:focus-visible {
+  background: rgba(148, 163, 184, 0.18);
+}
+
 .result__planner {
   display: flex;
   flex-direction: column;
@@ -303,6 +382,40 @@ main.layout {
   margin: 0;
   color: var(--color-text-muted);
   font-size: 0.9rem;
+}
+
+.planner__header {
+  align-items: center;
+  gap: 1rem;
+}
+
+.planner__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.planner__selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.planner__selector select {
+  min-width: 10.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-text);
+  padding: 0.55rem 0.85rem;
+}
+
+.planner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .planner__grid {
@@ -822,6 +935,37 @@ input:focus-visible {
 
   .result__planner {
     text-align: left;
+  }
+
+  .share-control {
+    width: 100%;
+  }
+
+  .share-control .share-menu {
+    left: 0;
+    right: auto;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .planner__selector {
+    flex-wrap: wrap;
+  }
+
+  .planner__selector select {
+    flex: 1;
+  }
+
+  .planner__actions {
+    width: 100%;
+    justify-content: stretch;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .planner__actions .share-control,
+  .planner__actions button {
+    width: 100%;
   }
 
   .planner__row {

--- a/index.html
+++ b/index.html
@@ -18,15 +18,18 @@
     </div>
     <nav class="topbar__nav" aria-label="Acciones">
       <span id="userWelcome" class="user-badge" hidden></span>
-      <button id="settingsButton" class="ghost" type="button" aria-haspopup="dialog" aria-controls="settingsPanel">
-        Configuración
+      <button id="settingsButton" class="ghost icon-label" type="button" aria-haspopup="dialog" aria-controls="settingsPanel">
+        <span class="icon" aria-hidden="true">⚙️</span>
+        <span class="label">Configuración</span>
       </button>
       <div class="auth-group">
-        <button id="authToggle" class="primary ghost" type="button" aria-haspopup="dialog" aria-controls="authDialog">
-          Iniciar sesión
+        <button id="authToggle" class="primary ghost icon-label" type="button" aria-haspopup="dialog" aria-controls="authDialog">
+          <span class="icon" aria-hidden="true">🔑</span>
+          <span class="label">Iniciar sesión</span>
         </button>
-        <button id="logoutButton" class="ghost" type="button">
-          Cerrar sesión
+        <button id="logoutButton" class="ghost icon-label" type="button">
+          <span class="icon" aria-hidden="true">🚪</span>
+          <span class="label">Cerrar sesión</span>
         </button>
       </div>
     </nav>
@@ -58,7 +61,38 @@
               <p class="result__subtitle" id="resultSubtitle">Inicia sesión y pulsa el botón para que Chefy te recomiende una receta increíble.</p>
             </div>
             <div class="result__actions">
-              <button id="shareButton" class="ghost" type="button" disabled>Compartir por WhatsApp</button>
+              <div class="share-control">
+                <button
+                  id="shareButton"
+                  class="ghost icon-label"
+                  type="button"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  aria-controls="shareMenu"
+                  disabled
+                >
+                  <span class="icon" aria-hidden="true">📤</span>
+                  <span class="label">Compartir receta</span>
+                </button>
+                <div id="shareMenu" class="share-menu" role="menu" data-share-type="recipe" hidden>
+                  <button type="button" class="share-option" data-share-target="whatsapp" role="menuitem">
+                    <span class="icon" aria-hidden="true">🟢</span>
+                    <span class="label">WhatsApp</span>
+                  </button>
+                  <button type="button" class="share-option" data-share-target="telegram" role="menuitem">
+                    <span class="icon" aria-hidden="true">✈️</span>
+                    <span class="label">Telegram</span>
+                  </button>
+                  <button type="button" class="share-option" data-share-target="email" role="menuitem">
+                    <span class="icon" aria-hidden="true">✉️</span>
+                    <span class="label">Correo</span>
+                  </button>
+                  <button type="button" class="share-option" data-share-target="copy" role="menuitem">
+                    <span class="icon" aria-hidden="true">📋</span>
+                    <span class="label">Copiar</span>
+                  </button>
+                </div>
+              </div>
               <div class="result__planner" aria-live="polite">
                 <label for="planDaySelect">Añadir al plan semanal</label>
                 <div class="result__planner-controls">
@@ -96,9 +130,55 @@
         </section>
 
         <section class="card planner" aria-labelledby="plannerTitle">
-          <header class="card__header">
-            <h2 id="plannerTitle">Planificador semanal</h2>
-            <button id="clearPlanButton" class="ghost" type="button">Limpiar plan</button>
+          <header class="card__header planner__header">
+            <div class="planner__title">
+              <h2 id="plannerTitle">Planificador semanal</h2>
+              <div class="planner__selector">
+                <label class="sr-only" for="planSelect">Planificación activa</label>
+                <select id="planSelect" name="planSelect" aria-label="Planificación activa"></select>
+                <button id="addPlanButton" class="ghost icon-only" type="button" aria-label="Crear nueva planificación">
+                  <span aria-hidden="true">＋</span>
+                </button>
+              </div>
+            </div>
+            <div class="planner__actions">
+              <div class="share-control">
+                <button
+                  id="sharePlanButton"
+                  class="ghost icon-label"
+                  type="button"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  aria-controls="planShareMenu"
+                  disabled
+                >
+                  <span class="icon" aria-hidden="true">🗓️</span>
+                  <span class="label">Compartir plan</span>
+                </button>
+                <div id="planShareMenu" class="share-menu" role="menu" data-share-type="plan" hidden>
+                  <button type="button" class="share-option" data-share-target="whatsapp" role="menuitem">
+                    <span class="icon" aria-hidden="true">🟢</span>
+                    <span class="label">WhatsApp</span>
+                  </button>
+                  <button type="button" class="share-option" data-share-target="telegram" role="menuitem">
+                    <span class="icon" aria-hidden="true">✈️</span>
+                    <span class="label">Telegram</span>
+                  </button>
+                  <button type="button" class="share-option" data-share-target="email" role="menuitem">
+                    <span class="icon" aria-hidden="true">✉️</span>
+                    <span class="label">Correo</span>
+                  </button>
+                  <button type="button" class="share-option" data-share-target="copy" role="menuitem">
+                    <span class="icon" aria-hidden="true">📋</span>
+                    <span class="label">Copiar</span>
+                  </button>
+                </div>
+              </div>
+              <button id="clearPlanButton" class="ghost icon-label" type="button">
+                <span class="icon" aria-hidden="true">🧹</span>
+                <span class="label">Limpiar plan</span>
+              </button>
+            </div>
           </header>
           <p class="card__hint">Organiza desayunos, comidas y cenas en un vistazo y mantén tus ideas siempre a mano.</p>
           <div class="planner__grid" id="weeklyPlanGrid" role="grid"></div>


### PR DESCRIPTION
## Summary
- add iconographic buttons in the header and action cards together with reusable share menus for recipes and plans
- support multiple weekly planning boards with a selector, creation flow, and synchronized storage
- improve sharing capabilities to cover WhatsApp, Telegram, email, and clipboard while fixing recipe history persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea2991184832b875792c38c645cfe