### PR TITLE
Fix login dialog runtime error

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2749,8 +2749,6 @@ function formatIngredients(list) {
     .filter(Boolean)
     .join('\n');
 }
-
-l 
 function parseIngredientPrices(value) {
   const lines = parseLines(value);
   const result = {};


### PR DESCRIPTION
## Summary
- remove an accidental stray character in `app.js` that caused a ReferenceError before the auth logic ran
- ensure the authentication dialog opens correctly so login works again

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf30e76810832ba9152e7e660d377b